### PR TITLE
feat: introduce unified GhostState/GhostCard system for empty states

### DIFF
--- a/src/app/dashboard/components/EnvironmentMobileCard.tsx
+++ b/src/app/dashboard/components/EnvironmentMobileCard.tsx
@@ -13,10 +13,6 @@ function getHealth(row: EnvironmentTableRow): HealthStatus {
 }
 
 function mapRowToCardData(row: EnvironmentTableRow): MobileCardData {
-    const tempDisplay = row.lastTemp !== null
-        ? `${row.lastTemp} ${row.lastTempUnit ?? '°C'}`
-        : '—';
-
     return {
         key: row.key,
         href: `/environments/${row.key}`,
@@ -27,34 +23,52 @@ function mapRowToCardData(row: EnvironmentTableRow): MobileCardData {
         ].filter(Boolean).join(' · '),
         health: getHealth(row),
         metrics: [
-            { label: 'TEMP', value: row.lastTemp, display: row.lastTemp !== null ? `${row.lastTemp}°` : '—', status: row.tempBad ? 'warn' : 'ok' },
-            { label: 'RLF', value: row.lastHumidity, display: row.lastHumidity !== null ? `${row.lastHumidity}%` : '—', status: row.humidityBad ? 'warn' : 'ok' },
-            { label: 'VPD', value: row.lastVpd, display: row.lastVpd !== null ? `${row.lastVpd}` : '—', status: row.vpdBad ? 'warn' : 'ok' },
-            { label: 'CO₂', value: row.lastCo2, display: row.lastCo2 !== null ? `${row.lastCo2}` : '—', status: row.co2Bad ? 'warn' : 'ok' },
+            {
+                label: 'TEMP',
+                value: row.lastTemp,
+                display: row.lastTemp !== null ? `${row.lastTemp}°` : '—',
+                status: row.tempBad ? 'warn' : 'ok',
+            },
+            {
+                label: 'RLF',
+                value: row.lastHumidity,
+                display: row.lastHumidity !== null ? `${row.lastHumidity}%` : '—',
+                status: row.humidityBad ? 'warn' : 'ok',
+            },
+            {
+                label: 'VPD',
+                value: row.lastVpd,
+                display: row.lastVpd !== null ? `${row.lastVpd}` : '—',
+                status: row.vpdBad ? 'warn' : 'ok',
+            },
+            {
+                label: 'CO₂',
+                value: row.lastCo2,
+                display: row.lastCo2 !== null ? `${row.lastCo2}` : '—',
+                status: row.co2Bad ? 'warn' : 'ok',
+            },
         ],
         sparkline: {
             data: row.tempHistory,
             color: CLIMATE_COLORS.temp.base,
             id: `spark_${row.key}`,
             label: 'TEMPERATUR · 30 TAGE',
-            currentValue: tempDisplay,
+            currentValue: row.lastTemp !== null ? `${row.lastTemp}°` : '—',
         },
         footerLabel: row.lastMeasurementDate,
     };
 }
 
-interface EnvironmentMobileListProps {
+interface Props {
     rows: EnvironmentTableRow[];
     onAddNew?: () => void;
 }
 
-export function EnvironmentMobileList({ rows, onAddNew }: EnvironmentMobileListProps) {
-    const items = rows.map(mapRowToCardData);
-
+export function EnvironmentMobileList({ rows, onAddNew }: Props) {
     return (
         <MobileList
             title="Environments"
-            items={items}
+            items={rows.map(mapRowToCardData)}
             searchFields={item => [item.title, item.subtitle]}
             onAddNew={onAddNew}
         />

--- a/src/app/dashboard/components/EnvironmentTab.tsx
+++ b/src/app/dashboard/components/EnvironmentTab.tsx
@@ -1,4 +1,5 @@
-"use client"
+"use client";
+
 import { EnvironmentTableCard } from '@/components/Table/TableCard';
 import { useRouter } from 'next/navigation';
 import TabContent from '@/components/TabContent/TabContent';
@@ -7,39 +8,55 @@ import { mapEnvironmentsToTableRows } from '@/components/Table/adapters/environm
 import { environmentTableConfig } from '@/config/environmentTableConfig';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { EnvironmentMobileList } from './EnvironmentMobileCard';
-import { useEnvironment } from '@/context/EnvironmentContext';
 import { usePlant } from '@/context/PlantContext';
+import { GhostState } from '@/app/environments/[environmentId]/components/shared/GhostState/GhostState';
+import { GhostCard } from '@/app/environments/[environmentId]/components/shared/GhostState/GhostCard';
+import { ENVIRONMENT_GHOST_ROWS } from './ghostEnvironmentRows';
+import { useDeleteEnvironments } from '@/hooks/useDeleteEnvironments';
 
-interface EnvironmentTabProps {
+interface Props {
     environments: EnvironmentData[];
     onAddNew?: () => void;
 }
 
-export default function EnvironmentTab({ environments, onAddNew }: EnvironmentTabProps) {
-    const { deleteEnvironments } = useEnvironment();
+export default function EnvironmentTab({ environments, onAddNew }: Props) {
+    const deleteEnvironments = useDeleteEnvironments();
     const { plants } = usePlant();
     const router = useRouter();
     const isMobile = useIsMobile();
-    const rows = mapEnvironmentsToTableRows(environments, plants);
+
+    const isEmpty = environments.length === 0;
+    const rows = isEmpty
+        ? ENVIRONMENT_GHOST_ROWS
+        : mapEnvironmentsToTableRows(environments, plants);
 
     return (
         <TabContent id="environments">
-            {isMobile ? (
-                <EnvironmentMobileList
-                    rows={rows}
-                    onAddNew={onAddNew}
-                />
-            ) : (
-                <EnvironmentTableCard
-                    data={rows}
-                    tableConfig={{
-                        ...environmentTableConfig,
-                        onDeleteSelected: (keys: string[]) => deleteEnvironments(keys),
-                        onRowClick: (row) => router.push(`/environments/${row.key}`),
-                        onAddNew,
-                    }}
-                />
-            )}
+            <GhostState
+                isEmpty={isEmpty}
+                overlay={
+                    <GhostCard
+                        title="Erste Umgebung anlegen"
+                        text="Erstelle deine erste Pflanzenumgebung und behalte Temperatur, Luftfeuchtigkeit und mehr im Blick."
+                        cta="Umgebung erstellen"
+                        onClick={onAddNew}
+                    />
+                }
+            >
+                {isMobile ? (
+                    <EnvironmentMobileList rows={rows} onAddNew={onAddNew} />
+                ) : (
+                    <EnvironmentTableCard
+                        data={rows}
+                        tableConfig={{
+                            ...environmentTableConfig,
+                            onDeleteSelected: (keys: string[]) => deleteEnvironments(keys),
+                            onRowClick: (row) => router.push(`/environments/${row.key}`),
+                            onAddNew,
+                        }}
+                    />
+                )}
+            </GhostState>
         </TabContent>
     );
 }

--- a/src/app/dashboard/components/RecentActivity.tsx
+++ b/src/app/dashboard/components/RecentActivity.tsx
@@ -6,11 +6,56 @@ import { EnvironmentData } from "@/types/environment";
 import { PlantData } from "@/types/plant";
 import TypeIcon from "@/components/TypeIcon/TypeIcon";
 import styles from "./RecentActivity.module.scss";
-import { getRecentActivity } from "@/helpers/getRecentActivity";
+import { ActivityEntry, getRecentActivity } from "@/helpers/getRecentActivity";
 import { dateKeyToTimestamp, formatDate, formatTime, groupEventsByDate } from "@/helpers/date";
 import { Card } from "@/components/Card/Card";
 import TabContent from "@/components/TabContent/TabContent";
-import EmptyState from "@/components/EmptyState/EmptyState";
+import { GhostState } from "@/app/environments/[environmentId]/components/shared/GhostState/GhostState";
+import { GhostCard } from "@/app/environments/[environmentId]/components/shared/GhostState/GhostCard";
+import { getIconConfig } from "@/config/icons";
+
+const GHOST_BASE = Date.UTC(2024, 0, 8, 12, 0, 0, 0);
+const DAY = 86_400_000;
+
+const GHOST_ENTRIES: ActivityEntry[] = [
+    {
+        id: "ghost-1",
+        kind: "event",
+        timestamp: GHOST_BASE,
+        iconConfig: getIconConfig("Cleaning")!,
+        title: "Reinigung",
+        subTitle: "Gewächshaus Nord",
+        href: "#",
+    },
+    {
+        id: "ghost-2",
+        kind: "measurement",
+        timestamp: GHOST_BASE - DAY,
+        iconConfig: getIconConfig("temp")!,
+        title: "Messung eingetragen",
+        subTitle: "Gewächshaus Nord",
+        href: "#",
+    },
+    {
+        id: "ghost-3",
+        kind: "event",
+        timestamp: GHOST_BASE - DAY * 2,
+        iconConfig: getIconConfig("FERTILIZING")!,
+        title: "Düngen · Bio-Bloom",
+        subTitle: "Tomatenpflanze · Gewächshaus Nord",
+        href: "#",
+    },
+    {
+        id: "ghost-4",
+        kind: "measurement",
+        timestamp: GHOST_BASE - DAY * 3,
+        iconConfig: getIconConfig("ph")!,
+        title: "Gegossen",
+        subTitle: "Tomatenpflanze · Gewächshaus Nord",
+        notes: "500 ml · pH 6.1 · EC 1.8",
+        href: "#",
+    },
+];
 
 interface RecentActivityProps {
     environments: EnvironmentData[];
@@ -18,7 +63,7 @@ interface RecentActivityProps {
     limit?: number;
 }
 
-const RecentActivityTab = ({ environments, plants, limit}: RecentActivityProps) => {
+const RecentActivityTab = ({ environments, plants, limit }: RecentActivityProps) => {
     const router = useRouter();
 
     const entries = useMemo(
@@ -26,56 +71,68 @@ const RecentActivityTab = ({ environments, plants, limit}: RecentActivityProps) 
         [environments, plants, limit]
     );
 
-    const grouped = groupEventsByDate(entries);
+    const isEmpty = entries.length === 0;
+    const displayEntries = isEmpty ? GHOST_ENTRIES : entries;
+    const grouped = groupEventsByDate(displayEntries);
+
+    const activityList = (
+        <div className={styles.wrapper}>
+            {grouped.map(([dateKey, items]) => (
+                <section key={dateKey} className={styles.group}>
+                    <time
+                        className={styles.dateLabel}
+                        dateTime={new Date(dateKeyToTimestamp(dateKey)).toISOString()}
+                    >
+                        {formatDate(dateKeyToTimestamp(dateKey))}
+                    </time>
+                    <ul className={styles.list}>
+                        {items.map(entry => (
+                            <li key={entry.id}>
+                                <button
+                                    className={styles.item}
+                                    onClick={() => router.push(entry.href)}
+                                >
+                                    <TypeIcon
+                                        icon={entry.iconConfig.icon}
+                                        customBgColor={entry.iconConfig.colors.soft}
+                                        customTextColor={entry.iconConfig.colors.base}
+                                        size="l"
+                                    />
+                                    <div className={styles.body}>
+                                        <span className={styles.title}>{entry.title}</span>
+                                        <div className={styles.meta}>
+                                            <span className={styles.subTitle}>{entry.subTitle}</span>
+                                        </div>
+                                    </div>
+                                    <time
+                                        className={styles.time}
+                                        dateTime={new Date(entry.timestamp).toISOString()}
+                                    >
+                                        {formatTime(entry.timestamp)}
+                                    </time>
+                                </button>
+                            </li>
+                        ))}
+                    </ul>
+                </section>
+            ))}
+        </div>
+    );
 
     return (
         <TabContent id="recent-activity">
             <Card title="Letzte Aktivitäten" collapsible>
-                {!entries.length ? (
-                    <EmptyState message="Noch keine Aktivitäten vorhanden." />
-                ) : (
-                    <div className={styles.wrapper}>
-                        {grouped.map(([dateKey, items]) => (
-                            <section key={dateKey} className={styles.group}>
-                                <time
-                                    className={styles.dateLabel}
-                                    dateTime={new Date(dateKeyToTimestamp(dateKey)).toISOString()}
-                                >
-                                    {formatDate(dateKeyToTimestamp(dateKey))}
-                                </time>
-                                <ul className={styles.list}>
-                                    {items.map(entry => (
-                                        <li key={entry.id}>
-                                            <button
-                                                className={styles.item}
-                                                onClick={() => router.push(entry.href)}
-                                            >
-                                                <TypeIcon
-                                                    icon={entry.iconConfig.icon}
-                                                    customBgColor={entry.iconConfig.colors.soft}
-                                                    customTextColor={entry.iconConfig.colors.base}
-                                                    size="l"
-                                                />
-                                                <div className={styles.body}>
-                                                    <span className={styles.title}>{entry.title}</span>
-                                                    <div className={styles.meta}>
-                                                        <span className={styles.subTitle}>{entry.subTitle}</span>
-                                                    </div>
-                                                </div>
-                                                <time
-                                                    className={styles.time}
-                                                    dateTime={new Date(entry.timestamp).toISOString()}
-                                                >
-                                                    {formatTime(entry.timestamp)}
-                                                </time>
-                                            </button>
-                                        </li>
-                                    ))}
-                                </ul>
-                            </section>
-                        ))}
-                    </div>
-                )}
+                <GhostState
+                    isEmpty={isEmpty}
+                    overlay={
+                        <GhostCard
+                            title="Noch keine Aktivitäten"
+                            text="Sobald du Events oder Messungen einträgst, erscheinen sie hier."
+                        />
+                    }
+                >
+                    {activityList}
+                </GhostState>
             </Card>
         </TabContent>
     );

--- a/src/app/dashboard/components/ghostEnvironmentRows.ts
+++ b/src/app/dashboard/components/ghostEnvironmentRows.ts
@@ -1,0 +1,27 @@
+import { EnvironmentTableRow } from '@/components/Table/adapters/environmentTableAdapter';
+import { createGhostEnvironmentRow } from '@/helpers/createGhostEnvironmnetRow';
+
+export const ENVIRONMENT_GHOST_ROWS: EnvironmentTableRow[] = [
+    createGhostEnvironmentRow({
+        key: 'ghost-1',
+        name: 'Gewächshaus Nord',
+        location: 'Keller',
+        lastTemp: 22.4,
+        lastHumidity: 58,
+        lastVpd: 1.1,
+        lastCo2: 820,
+        lastMeasurementDate: 'Vor 2 Stunden',
+        tempHistory: [21, 21.5, 22, 22.4],
+    }),
+    createGhostEnvironmentRow({
+        key: 'ghost-2',
+        name: 'Anzuchtstation',
+        location: 'Dachboden',
+        lastTemp: 19.8,
+        lastHumidity: 72,
+        lastVpd: 0.8,
+        lastCo2: 650,
+        lastMeasurementDate: 'Vor 5 Stunden',
+        tempHistory: [18, 19, 19.5, 19.8],
+    }),
+];

--- a/src/app/environments/[environmentId]/EnvironmentDetailView.tsx
+++ b/src/app/environments/[environmentId]/EnvironmentDetailView.tsx
@@ -100,7 +100,10 @@ export default function EnvironmentDetailView({ environmentId }: { environmentId
                 </div>
             )}
             <PlantsTab plants={plants} onAddNew={() => setModalType("newPlant")} />
-            <EnvironmentEventTab events={environment.events} />
+            <EnvironmentEventTab
+                events={environment.events}
+                onAddEvent={() => setModalType("event")}
+            />
 
             <DataTab
                 data={chartData}

--- a/src/app/environments/[environmentId]/components/PlantMobileCard.tsx
+++ b/src/app/environments/[environmentId]/components/PlantMobileCard.tsx
@@ -1,4 +1,5 @@
-"use client"
+"use client";
+
 import { WATER_COLORS } from '@/config/icons';
 import { PlantTableRow } from '@/components/Table/adapters/plantTableAdapter';
 import { MobileList, MobileCardData, HealthStatus, getMetricStatus } from '@/components/MobileCard/MobileCard';
@@ -13,10 +14,6 @@ function getHealth(_row: PlantTableRow): HealthStatus {
 }
 
 function mapRowToCardData(row: PlantTableRow): MobileCardData {
-    const phDisplay = row.phValue !== null
-        ? `${row.phValue} ${row.phUnit ?? ''}`
-        : '—';
-
     return {
         key: row.key,
         href: `/environments/${row.environmentId}/plants/${row.key}`,
@@ -24,15 +21,27 @@ function mapRowToCardData(row: PlantTableRow): MobileCardData {
         subtitle: row.species,
         health: getHealth(row),
         metrics: [
-            { label: 'PH', value: row.phValue, display: row.phValue !== null ? `${row.phValue}` : '—', status: getMetricStatus(row.phValue, RANGES, 'ph') },
-            { label: 'EC', value: row.ecValue, display: row.ecValue !== null ? `${row.ecValue}` : '—', status: getMetricStatus(row.ecValue, RANGES, 'ec') },
+            {
+                label: 'PH',
+                value: row.phValue,
+                display: row.phValue !== null ? `${row.phValue}` : '—',
+                status: getMetricStatus(row.phValue, RANGES, 'ph'),
+            },
+            {
+                label: 'EC',
+                value: row.ecValue,
+                display: row.ecValue !== null ? `${row.ecValue}` : '—',
+                status: getMetricStatus(row.ecValue, RANGES, 'ec'),
+            },
         ],
         sparkline: {
-            data:         row.phHistory,
-            color:        WATER_COLORS.ph.base,
-            id:           `spark_${row.key}`,
-            label:        'PH · 30 TAGE',
-            currentValue: phDisplay,
+            data: row.phHistory,
+            color: WATER_COLORS.ph.base,
+            id: `spark_${row.key}`,
+            label: 'PH · 30 TAGE',
+            currentValue: row.phValue !== null
+                ? `${row.phValue} ${row.phUnit ?? ''}`
+                : '—',
         },
         footerLabel: row.lastWateringDate,
     };
@@ -44,12 +53,10 @@ interface PlantMobileListProps {
 }
 
 export function PlantMobileList({ rows, onAddNew }: PlantMobileListProps) {
-    const items = rows.map(mapRowToCardData);
-
     return (
         <MobileList
             title="Pflanzen"
-            items={items}
+            items={rows.map(mapRowToCardData)}
             searchFields={item => [item.title, item.subtitle]}
             onAddNew={onAddNew}
         />

--- a/src/app/environments/[environmentId]/components/PlantsTab.tsx
+++ b/src/app/environments/[environmentId]/components/PlantsTab.tsx
@@ -7,6 +7,9 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { PlantMobileList } from './PlantMobileCard';
 import TabContent from '@/components/TabContent/TabContent';
 import { usePlant } from '@/context/PlantContext';
+import { GhostState } from './shared/GhostState/GhostState';
+import { GhostCard } from './shared/GhostState/GhostCard';
+import { PLANT_GHOST_ROWS } from './ghostPlantRows';
 
 interface PlantsTabProps {
     plants: PlantData[];
@@ -15,27 +18,39 @@ interface PlantsTabProps {
 
 export default function PlantsTab({ plants, onAddNew }: PlantsTabProps) {
     const { deletePlants } = usePlant();
-    const rows = mapPlantsToTableRows(plants);
-    const router = useRouter()
+    const router = useRouter();
     const isMobile = useIsMobile();
-    
+
+    const isEmpty = plants.length === 0;
+    const rows = isEmpty ? PLANT_GHOST_ROWS : mapPlantsToTableRows(plants);
+
     return (
         <TabContent id="plants">
-            {isMobile ? (
-                <PlantMobileList rows={rows} onAddNew={onAddNew} />
-            ) : (
-                <PlantTableCard
-                    data={rows}
-                    tableConfig={{
-                        ...plantTableConfig,
-                        onDeleteSelected: (keys: string[]) => deletePlants(keys),
-                        onRowClick: (row) => {
-                            router.push(`/environments/${row.environmentId}/plants/${row.key}`);
-                        },
-                        onAddNew
-                    }}
-                />
-            )}
+            <GhostState
+                isEmpty={isEmpty}
+                overlay={
+                    <GhostCard
+                        title="Erste Pflanze anlegen"
+                        text="Füge deine erste Pflanze hinzu und verfolge pH, EC und Gießverlauf."
+                        cta="Pflanze anlegen"
+                        onClick={onAddNew}
+                    />
+                }
+            >
+                {isMobile ? (
+                    <PlantMobileList rows={rows} onAddNew={onAddNew} />
+                ) : (
+                    <PlantTableCard
+                        data={rows}
+                        tableConfig={{
+                            ...plantTableConfig,
+                            onDeleteSelected: (keys: string[]) => deletePlants(keys),
+                            onRowClick: (row) => router.push(`/environments/${row.environmentId}/plants/${row.key}`),
+                            onAddNew,
+                        }}
+                    />
+                )}
+            </GhostState>
         </TabContent>
     );
 }

--- a/src/app/environments/[environmentId]/components/ghostPlantRows.ts
+++ b/src/app/environments/[environmentId]/components/ghostPlantRows.ts
@@ -1,0 +1,29 @@
+import { PlantTableRow } from '@/components/Table/adapters/plantTableAdapter';
+import { createGhostPlantRow } from '@/helpers/createGhostPlantRow';
+
+export const PLANT_GHOST_ROWS: PlantTableRow[] = [
+    createGhostPlantRow({
+        key: 'ghost-1',
+        title: 'Tomatenpflanze',
+        species: 'Solanum lycopersicum',
+        phValue: 6.1,
+        phUnit: 'pH',
+        ecValue: 1.8,
+        ecUnit: 'mS/cm',
+        lastWateringDate: 'Vor 1 Tag',
+        phHistory: [5.9, 6.0, 6.1, 6.1],
+        ecHistory: [1.6, 1.7, 1.8, 1.8],
+    }),
+    createGhostPlantRow({
+        key: 'ghost-2',
+        title: 'Basilikum',
+        species: 'Ocimum basilicum',
+        phValue: 5.8,
+        phUnit: 'pH',
+        ecValue: 1.2,
+        ecUnit: 'mS/cm',
+        lastWateringDate: 'Vor 3 Tagen',
+        phHistory: [5.6, 5.7, 5.8, 5.8],
+        ecHistory: [1.1, 1.2, 1.2, 1.2],
+    }),
+];

--- a/src/app/environments/[environmentId]/components/shared/DataTab/DataTab.module.scss
+++ b/src/app/environments/[environmentId]/components/shared/DataTab/DataTab.module.scss
@@ -46,11 +46,6 @@
   }
 }
 
-.metricRowGhost {
-  pointer-events: none;
-  user-select: none;
-}
-
 .metricLeft {
   display: flex;
   flex-direction: column;
@@ -71,11 +66,6 @@
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-}
-
-.metricBadge{
-  color: var(--color-text-success);
-  background: var(--color-flag-success);
 }
 
 .metricLabel {
@@ -169,55 +159,4 @@
 .chartMountPlaceholder {
   width: 100%;
   height: 100%;
-}
-
-.ghostWrapper {
-  position: relative;
-}
-
-.ghostContent {
-  opacity: 0.5;
-  filter: saturate(0.4);
-  pointer-events: none;
-  user-select: none;
-}
-
-.ghostOverlay {
-  position: absolute;
-  inset: 0;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: var(--spacing-xl);
-}
-
-.ghostOverlayCard {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: var(--spacing-m);
-  text-align: center;
-  background-color: var(--color-background-primary);
-  border: 1px solid var(--color-border-primary);
-  border-radius: var(--radius-l);
-  padding: var(--spacing-xl);
-  max-width: 320px;
-  width: 100%;
-  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
-}
-
-.ghostOverlayTitle {
-  font-size: var(--font-size-m);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-text-primary);
-  margin: 0;
-}
-
-.ghostOverlayText {
-  font-size: var(--font-size-xs);
-  color: var(--color-text-tertiary);
-  max-width: 240px;
-  line-height: 1.5;
-  margin: 0;
 }

--- a/src/app/environments/[environmentId]/components/shared/DataTab/DataTab.tsx
+++ b/src/app/environments/[environmentId]/components/shared/DataTab/DataTab.tsx
@@ -10,11 +10,7 @@ import {
     Tooltip,
     ResponsiveContainer,
 } from "recharts";
-import {
-    TrendingUp,
-    TrendingDown,
-    Minus,
-} from "lucide-react";
+import { TrendingUp, TrendingDown, Minus } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import styles from "./DataTab.module.scss";
 import { Card } from "@/components/Card/Card";
@@ -22,8 +18,9 @@ import { formatDate, formatDateShort } from "@/helpers/date";
 import { TimeSeriesEntry } from "@/types/events";
 import { DEVIATION_STYLES, DeviationLevel } from "@/config/icons";
 import { UnitToggle } from "./UnitToggle";
-import { Button } from "@/components/Button/Button";
 import TabContent from "@/components/TabContent/TabContent";
+import { GhostState } from "../GhostState/GhostState";
+import { GhostCard } from "../GhostState/GhostCard";
 
 export interface MetricConfig {
     key: string;
@@ -48,11 +45,6 @@ interface Trend {
     pct: string;
 }
 
-const GHOST_BASE_TIMESTAMP = Date.UTC(2024, 0, 1, 12, 0, 0, 0);
-const GHOST_OK_TEXT = "var(--color-text-success)";
-const GHOST_OK_BG = "var(--color-flag-success)";
-const GHOST_ICON_COLOR = "var(--color-text-tertiary)";
-
 interface MetricRowProps {
     metric: MetricConfig;
     data: TimeSeriesEntry[];
@@ -62,12 +54,39 @@ interface MetricRowProps {
     onToggleFahrenheit?: (v: boolean) => void;
 }
 
+interface GhostMetricRowProps {
+    metric: MetricConfig;
+    chartsMounted: boolean;
+}
+
+interface AreaTooltipProps {
+    active?: boolean;
+    payload?: readonly { value: number; name: string; color: string }[];
+    label?: string | number;
+    metric: MetricConfig;
+}
+
+interface DataTabProps {
+    data: TimeSeriesEntry[];
+    metrics: MetricConfig[];
+    title: string;
+    emptyTitle: string;
+    emptyText: string;
+    ctaLabel: string;
+    onAddMeasurement?: () => void;
+    id?: string;
+}
+
+const GHOST_BASE_TIMESTAMP = Date.UTC(2024, 0, 1, 12, 0, 0, 0);
+const GHOST_OK_TEXT = "var(--color-text-success)";
+const GHOST_OK_BG = "var(--color-flag-success)";
+
 function toRangePercent(value: number, min: number, max: number): number {
     return Math.min(100, Math.max(0, ((value - min) / (max - min)) * 100));
 }
 
 function getMetricValue(entry: TimeSeriesEntry, key: string): number | undefined {
-    return entry.metrics?.[key];
+    return entry?.metrics?.[key];
 }
 
 function getTrend(data: TimeSeriesEntry[], key: string): Trend | null {
@@ -105,11 +124,14 @@ function getDisplayMetric(metric: MetricConfig, useFahrenheit: boolean): MetricC
     };
 }
 
-interface AreaTooltipProps {
-    active?: boolean;
-    payload?: readonly { value: number; name: string; color: string }[];
-    label?: string | number;
-    metric: MetricConfig;
+function generateGhostData(idealMin: number, idealMax: number): ChartDatum[] {
+    const mid = (idealMin + idealMax) / 2;
+    const range = (idealMax - idealMin) * 0.4;
+    const offsets = [0.2, -0.1, 0.4, 0.1, -0.2, 0.5, 0.3, -0.15, 0.35, 0.2, -0.05, 0.25];
+    return offsets.map((o, i) => ({
+        t: GHOST_BASE_TIMESTAMP - (offsets.length - 1 - i) * 3600000,
+        v: mid + o * range,
+    }));
 }
 
 function AreaTooltip({ active, payload, label, metric }: AreaTooltipProps) {
@@ -127,180 +149,19 @@ function AreaTooltip({ active, payload, label, metric }: AreaTooltipProps) {
     );
 }
 
-function MetricRow({ metric, data, hasHistory, chartsMounted, useFahrenheit = false, onToggleFahrenheit }: MetricRowProps) {
-    const rawLatest = getMetricValue(data[data.length - 1], metric.key);
-    if (rawLatest === undefined) return null;
-
-    const displayMetric = getDisplayMetric(metric, useFahrenheit);
-    const displayLatest = metric.key === "temp" && useFahrenheit ? toF(rawLatest) : rawLatest;
-
-    const deviation = getDeviationLevel(rawLatest, metric);
-    const deviationStyle = DEVIATION_STYLES[deviation];
-
-    const trend = getTrend(data, metric.key);
-    const valuePct = toRangePercent(displayLatest, displayMetric.min, displayMetric.max);
-    const idealStartPct = toRangePercent(displayMetric.idealMin, displayMetric.min, displayMetric.max);
-    const idealWidthPct = toRangePercent(displayMetric.idealMax, displayMetric.min, displayMetric.max) - idealStartPct;
-
-    const chartData: ChartDatum[] = data
-        .map(entry => {
-            const v = getMetricValue(entry, metric.key);
-            if (v === undefined) return undefined;
-            const displayed = metric.key === "temp" && useFahrenheit ? toF(v) : v;
-            return { t: entry.timestamp, v: displayed };
-        })
-        .filter(Boolean) as ChartDatum[];
-
-    const TrendIcon = !trend ? Minus : trend.diff > 0 ? TrendingUp : TrendingDown;
-    const trendColor = !trend ? undefined : deviationStyle.color;
-    const Icon = metric.icon;
-
-    return (
-        <div className={styles.metricRow}>
-            <div className={styles.metricLeft}>
-                <div className={styles.metricHeader}>
-                    <div
-                        className={styles.metricIconWrap}
-                        style={{ background: `${metric.color}18` }}
-                    >
-                        <Icon size={14} color={metric.color} />
-                    </div>
-                    <span className={styles.metricLabel}>{metric.label}</span>
-                    {metric.key === "temp" && onToggleFahrenheit && (
-                        <UnitToggle
-                            options={[{ label: "°C", value: "c" }, { label: "°F", value: "f" }]}
-                            value={useFahrenheit ? "f" : "c"}
-                            onChange={(v) => onToggleFahrenheit(v === "f")}
-                        />
-                    )}
-                    <span
-                        className={styles.metricBadge}
-                        style={{
-                            color: deviationStyle.color,
-                            background: deviationStyle.background,
-                        }}
-                    >
-                        {deviationStyle.statusText}
-                    </span>
-                </div>
-
-                <div className={styles.metricValueRow}>
-                    <span className={styles.metricValue} style={{ color: metric.color }}>
-                        {displayMetric.format(displayLatest)}
-                    </span>
-                    {trend && (
-                        <span
-                            className={styles.metricTrend}
-                            style={{
-                                color: trendColor,
-                                background: `${trendColor}18`,
-                            }}
-                        >
-                            <TrendIcon size={13} />
-                            {trend.diff > 0 ? "+" : ""}
-                            {trend.pct}%
-                        </span>
-                    )}
-                </div>
-
-                <div className={styles.rangeBar}>
-                    <div
-                        className={styles.rangeIdeal}
-                        style={{
-                            left: `${idealStartPct}%`,
-                            width: `${idealWidthPct}%`,
-                            background: `${metric.color}30`,
-                        }}
-                    />
-                    <div
-                        className={styles.rangeMarker}
-                        style={{
-                            left: `calc(${valuePct}% - 6px)`,
-                            background: metric.color,
-                            boxShadow: `0 0 6px ${metric.color}88`,
-                        }}
-                    />
-                </div>
-
-                <div className={styles.rangeLabels}>
-                    <span>{displayMetric.min.toFixed(0)} {displayMetric.unit}</span>
-                    <span>Ziel: {displayMetric.idealMin.toFixed(0)}–{displayMetric.idealMax.toFixed(0)}</span>
-                    <span>{displayMetric.max.toFixed(0)} {displayMetric.unit}</span>
-                </div>
-
-                {hasHistory && (
-                    <div className={styles.metricSparkline}>
-                        {chartsMounted ? (
-                            <ResponsiveContainer width="100%" height="100%">
-                                <AreaChart data={chartData} margin={{ top: 2, right: 0, left: 0, bottom: 0 }}>
-                                    <defs>
-                                        <linearGradient id={`spark-${metric.key}`} x1="0" y1="0" x2="0" y2="1">
-                                            <stop offset="0%" stopColor={metric.color} stopOpacity={0.25} />
-                                            <stop offset="100%" stopColor={metric.color} stopOpacity={0} />
-                                        </linearGradient>
-                                    </defs>
-                                    <Area type="monotone" dataKey="v" stroke={metric.color} strokeWidth={1.5} fill={`url(#spark-${metric.key})`} dot={false} isAnimationActive={false} />
-                                    <YAxis domain={["auto", "auto"]} hide />
-                                </AreaChart>
-                            </ResponsiveContainer>
-                        ) : (
-                            <div className={styles.chartMountPlaceholder} aria-hidden />
-                        )}
-                    </div>
-                )}
-            </div>
-
-            {hasHistory && (
-                <div className={styles.metricChart}>
-                    {chartsMounted ? (
-                        <ResponsiveContainer width="100%" height="100%">
-                            <AreaChart data={chartData} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
-                                <defs>
-                                    <linearGradient id={`grad-${metric.key}`} x1="0" y1="0" x2="0" y2="1">
-                                        <stop offset="0%" stopColor={metric.color} stopOpacity={0.25} />
-                                        <stop offset="100%" stopColor={metric.color} stopOpacity={0} />
-                                    </linearGradient>
-                                </defs>
-                                <Area type="monotone" dataKey="v" stroke={metric.color} strokeWidth={2} fill={`url(#grad-${metric.key})`} dot={false} isAnimationActive={false} />
-                                <YAxis domain={["auto", "auto"]} hide />
-                                <XAxis dataKey="t" hide={false} tickFormatter={value => formatDate(value)} />
-                                <Tooltip content={props => <AreaTooltip {...props} metric={displayMetric} />} />
-                            </AreaChart>
-                        </ResponsiveContainer>
-                    ) : (
-                        <div className={styles.chartMountPlaceholder} aria-hidden />
-                    )}
-                </div>
-            )}
-        </div>
-    );
-}
-
-function generateGhostData(idealMin: number, idealMax: number): ChartDatum[] {
-    const mid = (idealMin + idealMax) / 2;
-    const range = (idealMax - idealMin) * 0.4;
-    const offsets = [0.2, -0.1, 0.4, 0.1, -0.2, 0.5, 0.3, -0.15, 0.35, 0.2, -0.05, 0.25];
-    return offsets.map((o, i) => ({
-        t: GHOST_BASE_TIMESTAMP - (offsets.length - 1 - i) * 3600000,
-        v: mid + o * range,
-    }));
-}
-
-interface GhostMetricRowProps {
-    metric: MetricConfig;
-    chartsMounted: boolean;
-}
-
 function GhostMetricRow({ metric, chartsMounted }: GhostMetricRowProps) {
     const mid = (metric.idealMin + metric.idealMax) / 2;
-    const ghostData = useMemo(() => generateGhostData(metric.idealMin, metric.idealMax), [metric.idealMin, metric.idealMax]);
+    const ghostData = useMemo(
+        () => generateGhostData(metric.idealMin, metric.idealMax),
+        [metric.idealMin, metric.idealMax]
+    );
     const valuePct = toRangePercent(mid, metric.min, metric.max);
     const idealStartPct = toRangePercent(metric.idealMin, metric.min, metric.max);
     const idealWidthPct = toRangePercent(metric.idealMax, metric.min, metric.max) - idealStartPct;
     const Icon = metric.icon;
 
     return (
-        <div className={`${styles.metricRow} ${styles.metricRowGhost}`}>
+        <div className={styles.metricRow}>
             <div className={styles.metricLeft}>
                 <div className={styles.metricHeader}>
                     <div className={styles.metricIconWrap} style={{ background: `${metric.color}18` }}>
@@ -359,18 +220,124 @@ function GhostMetricRow({ metric, chartsMounted }: GhostMetricRowProps) {
     );
 }
 
-interface DataTabProps {
-    data: TimeSeriesEntry[];
-    metrics: MetricConfig[];
-    title: string;
-    emptyTitle: string;
-    emptyText: string;
-    ctaLabel: string;
-    onAddMeasurement?: () => void;
-    id?: string,
+function MetricRow({ metric, data, hasHistory, chartsMounted, useFahrenheit = false, onToggleFahrenheit }: MetricRowProps) {
+    const rawLatest = getMetricValue(data[data.length - 1], metric.key);
+    if (rawLatest === undefined) return null;
+
+    const displayMetric = getDisplayMetric(metric, useFahrenheit);
+    const displayLatest = metric.key === "temp" && useFahrenheit ? toF(rawLatest) : rawLatest;
+    const deviation = getDeviationLevel(rawLatest, metric);
+    const deviationStyle = DEVIATION_STYLES[deviation];
+    const trend = getTrend(data, metric.key);
+    const valuePct = toRangePercent(displayLatest, displayMetric.min, displayMetric.max);
+    const idealStartPct = toRangePercent(displayMetric.idealMin, displayMetric.min, displayMetric.max);
+    const idealWidthPct = toRangePercent(displayMetric.idealMax, displayMetric.min, displayMetric.max) - idealStartPct;
+
+    const chartData: ChartDatum[] = data
+        .map(entry => {
+            const v = getMetricValue(entry, metric.key);
+            if (v === undefined) return undefined;
+            const displayed = metric.key === "temp" && useFahrenheit ? toF(v) : v;
+            return { t: entry.timestamp, v: displayed };
+        })
+        .filter(Boolean) as ChartDatum[];
+
+    const TrendIcon = !trend ? Minus : trend.diff > 0 ? TrendingUp : TrendingDown;
+    const trendColor = !trend ? undefined : deviationStyle.color;
+    const Icon = metric.icon;
+
+    return (
+        <div className={styles.metricRow}>
+            <div className={styles.metricLeft}>
+                <div className={styles.metricHeader}>
+                    <div className={styles.metricIconWrap} style={{ background: `${metric.color}18` }}>
+                        <Icon size={14} color={metric.color} />
+                    </div>
+                    <span className={styles.metricLabel}>{metric.label}</span>
+                    {metric.key === "temp" && onToggleFahrenheit && (
+                        <UnitToggle
+                            options={[{ label: "°C", value: "c" }, { label: "°F", value: "f" }]}
+                            value={useFahrenheit ? "f" : "c"}
+                            onChange={(v) => onToggleFahrenheit(v === "f")}
+                        />
+                    )}
+                    <span className={styles.metricBadge} style={{ color: deviationStyle.color, background: deviationStyle.background }}>
+                        {deviationStyle.statusText}
+                    </span>
+                </div>
+
+                <div className={styles.metricValueRow}>
+                    <span className={styles.metricValue} style={{ color: metric.color }}>
+                        {displayMetric.format(displayLatest)}
+                    </span>
+                    {trend && (
+                        <span className={styles.metricTrend} style={{ color: trendColor, background: `${trendColor}18` }}>
+                            <TrendIcon size={13} />
+                            {trend.diff > 0 ? "+" : ""}{trend.pct}%
+                        </span>
+                    )}
+                </div>
+
+                <div className={styles.rangeBar}>
+                    <div className={styles.rangeIdeal} style={{ left: `${idealStartPct}%`, width: `${idealWidthPct}%`, background: `${metric.color}30` }} />
+                    <div className={styles.rangeMarker} style={{ left: `calc(${valuePct}% - 6px)`, background: metric.color, boxShadow: `0 0 6px ${metric.color}88` }} />
+                </div>
+
+                <div className={styles.rangeLabels}>
+                    <span>{displayMetric.min.toFixed(0)} {displayMetric.unit}</span>
+                    <span>Ziel: {displayMetric.idealMin.toFixed(0)}–{displayMetric.idealMax.toFixed(0)}</span>
+                    <span>{displayMetric.max.toFixed(0)} {displayMetric.unit}</span>
+                </div>
+
+                {hasHistory && (
+                    <div className={styles.metricSparkline}>
+                        {chartsMounted ? (
+                            <ResponsiveContainer width="100%" height="100%">
+                                <AreaChart data={chartData} margin={{ top: 2, right: 0, left: 0, bottom: 0 }}>
+                                    <defs>
+                                        <linearGradient id={`spark-${metric.key}`} x1="0" y1="0" x2="0" y2="1">
+                                            <stop offset="0%" stopColor={metric.color} stopOpacity={0.25} />
+                                            <stop offset="100%" stopColor={metric.color} stopOpacity={0} />
+                                        </linearGradient>
+                                    </defs>
+                                    <Area type="monotone" dataKey="v" stroke={metric.color} strokeWidth={1.5} fill={`url(#spark-${metric.key})`} dot={false} isAnimationActive={false} />
+                                    <YAxis domain={["auto", "auto"]} hide />
+                                </AreaChart>
+                            </ResponsiveContainer>
+                        ) : (
+                            <div className={styles.chartMountPlaceholder} aria-hidden />
+                        )}
+                    </div>
+                )}
+            </div>
+
+            {hasHistory && (
+                <div className={styles.metricChart}>
+                    {chartsMounted ? (
+                        <ResponsiveContainer width="100%" height="100%">
+                            <AreaChart data={chartData} margin={{ top: 4, right: 4, left: 0, bottom: 0 }}>
+                                <defs>
+                                    <linearGradient id={`grad-${metric.key}`} x1="0" y1="0" x2="0" y2="1">
+                                        <stop offset="0%" stopColor={metric.color} stopOpacity={0.25} />
+                                        <stop offset="100%" stopColor={metric.color} stopOpacity={0} />
+                                    </linearGradient>
+                                </defs>
+                                <Area type="monotone" dataKey="v" stroke={metric.color} strokeWidth={2} fill={`url(#grad-${metric.key})`} dot={false} isAnimationActive={false} />
+                                <YAxis domain={["auto", "auto"]} hide />
+                                <XAxis dataKey="t" hide={false} tickFormatter={value => formatDate(value)} />
+                                <Tooltip content={props => <AreaTooltip {...props} metric={displayMetric} />} />
+                            </AreaChart>
+                        </ResponsiveContainer>
+                    ) : (
+                        <div className={styles.chartMountPlaceholder} aria-hidden />
+                    )}
+                </div>
+            )}
+        </div>
+    );
 }
 
-export default function DataTab({ data, metrics, onAddMeasurement, title, emptyTitle, emptyText, ctaLabel}: DataTabProps) {
+export default function DataTab({ data, metrics, onAddMeasurement, title, emptyTitle, emptyText, ctaLabel }: DataTabProps) {
     const hasHistory = data.length > 1;
     const isEmpty = data.length < 2;
     const [useFahrenheit, setUseFahrenheit] = useState(false);
@@ -379,47 +346,36 @@ export default function DataTab({ data, metrics, onAddMeasurement, title, emptyT
     return (
         <TabContent>
             <Card title={title} collapsible={true}>
-                {isEmpty ? (
-                    <div className={styles.ghostWrapper}>
-                        <div className={styles.ghostContent}>
-                            <div className={styles.metricList}>
-                                {metrics.map(metric => (
-                                    <GhostMetricRow key={metric.key} metric={metric} chartsMounted={chartsMounted} />
-                                ))}
-                            </div>
-                        </div>
-                        <div className={styles.ghostOverlay}>
-                            <div className={styles.ghostOverlayCard}>
-                                <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" style={{ color: GHOST_ICON_COLOR }}>
-                                    <path d="M3 3v18h18" /><path d="m19 9-5 5-4-4-3 3" />
-                                </svg>
-                                <p className={styles.ghostOverlayTitle}>{emptyTitle}</p>
-                                <p className={styles.ghostOverlayText}>
-                                    {emptyText}
-                                </p>
-                                {onAddMeasurement && (
-                                    <Button variant="secondary" type="button" onClick={onAddMeasurement}>
-                                        {ctaLabel}
-                                    </Button>
-                                )}
-                            </div>
-                        </div>
-                    </div>
-                ) : (
+                <GhostState
+                    isEmpty={isEmpty}
+                    overlay={
+                        <GhostCard
+                            title={emptyTitle}
+                            text={emptyText}
+                            cta={ctaLabel}
+                            onClick={onAddMeasurement}
+                        />
+                    }
+                >
                     <div className={styles.metricList}>
-                        {metrics.map(metric => (
-                            <MetricRow
-                                key={metric.key}
-                                metric={metric}
-                                data={data}
-                                hasHistory={hasHistory}
-                                chartsMounted={chartsMounted}
-                                useFahrenheit={useFahrenheit}
-                                onToggleFahrenheit={metric.key === "temp" ? setUseFahrenheit : undefined}
-                            />
-                        ))}
+                        {isEmpty
+                            ? metrics.map(metric => (
+                                <GhostMetricRow key={metric.key} metric={metric} chartsMounted={chartsMounted} />
+                            ))
+                            : metrics.map(metric => (
+                                <MetricRow
+                                    key={metric.key}
+                                    metric={metric}
+                                    data={data}
+                                    hasHistory={hasHistory}
+                                    chartsMounted={chartsMounted}
+                                    useFahrenheit={useFahrenheit}
+                                    onToggleFahrenheit={metric.key === "temp" ? setUseFahrenheit : undefined}
+                                />
+                            ))
+                        }
                     </div>
-                )}
+                </GhostState>
             </Card>
         </TabContent>
     );

--- a/src/app/environments/[environmentId]/components/shared/EventsList.tsx
+++ b/src/app/environments/[environmentId]/components/shared/EventsList.tsx
@@ -5,14 +5,17 @@ import { BaseEvent } from "@/types/events";
 import { iconMap } from "@/types/icons";
 import styles from "./EventsList.module.scss";
 import { dateKeyToTimestamp, formatDate, formatTime, groupEventsByDate } from "@/helpers/date";
-import { Leaf, TrendingUp } from "lucide-react";
+import { Leaf } from "lucide-react";
 import TypeIcon from "@/components/TypeIcon/TypeIcon";
 import { getEventConfig } from "@/config/icons";
-import { Button } from "@/components/Button/Button";
+import { GhostState } from "./GhostState/GhostState";
+import { GhostCard } from "./GhostState/GhostCard";
 
 interface EventsListProps<T extends BaseEvent> {
     events: T[];
     emptyMessage: string;
+    emptyTitle?: string;
+    ctaLabel?: string;
     getTitle: (event: T) => string;
     onAddEvent?: () => void;
     children?: (event: T) => React.ReactNode;
@@ -29,7 +32,6 @@ const EventCard = ({ event, title }: EventCardProps) => {
     const eventConfig = getEventConfig(event.type);
 
     let IconComponent = Leaf;
-
     if (event.customIconName && iconMap[event.customIconName]) {
         IconComponent = iconMap[event.customIconName];
     } else if (eventConfig?.icon) {
@@ -51,7 +53,7 @@ const EventCard = ({ event, title }: EventCardProps) => {
             <div className={styles.eventInfoWrapper}>
                 <h4>{title}</h4>
                 <p className={styles.eventNotes}>
-                    {event.notes ? event.notes : "Keine Notizen vorhanden"}
+                    {event.notes ?? "Keine Notizen vorhanden"}
                 </p>
             </div>
             <span className={styles.eventTime}>{formatTime(event.timestamp)}</span>
@@ -61,65 +63,24 @@ const EventCard = ({ event, title }: EventCardProps) => {
 
 function generateExampleEvents(): BaseEvent[] {
     const day = 86_400_000;
-
     return [
-        {
-            id: "ghost-1",
-            type: "Cleaning",
-            timestamp: EXAMPLE_BASE_TIMESTAMP,
-            notes: "Substrate gewechselt",
-        },
-        {
-            id: "ghost-2",
-            type: "Equipment_Change",
-            timestamp: EXAMPLE_BASE_TIMESTAMP,
-            notes: undefined,
-        },
-        {
-            id: "ghost-3",
-            type: "Maintenance",
-            timestamp: EXAMPLE_BASE_TIMESTAMP - day * 3,
-            notes: "Filter gereinigt",
-        },
-        {
-            id: "ghost-4",
-            type: "Cleaning",
-            timestamp: EXAMPLE_BASE_TIMESTAMP - day * 7,
-            notes: undefined,
-        },
+        { id: "ghost-1", type: "Cleaning",        timestamp: EXAMPLE_BASE_TIMESTAMP,           notes: "Substrate gewechselt" },
+        { id: "ghost-2", type: "Equipment_Change", timestamp: EXAMPLE_BASE_TIMESTAMP,           notes: undefined },
+        { id: "ghost-3", type: "Maintenance",      timestamp: EXAMPLE_BASE_TIMESTAMP - day * 3, notes: "Filter gereinigt" },
+        { id: "ghost-4", type: "Cleaning",         timestamp: EXAMPLE_BASE_TIMESTAMP - day * 7, notes: undefined },
     ];
-}
-
-interface ExampleOverlayProps {
-    message: string;
-    onAddEvent?: () => void;
-}
-
-function ExampleOverlay({ message, onAddEvent }: ExampleOverlayProps) {
-    return (
-        <div className={styles.exampleOverlay}>
-            <div className={styles.exampleOverlayCard}>
-                <TrendingUp size={28} strokeWidth={1.5} />
-                <p>Verlauf aktivieren</p>
-                <p className={styles.exampleOverlayDescription}>{message}</p>
-                {onAddEvent && (
-                    <Button variant="secondary" type="button" onClick={onAddEvent}>
-                        Event eintragen
-                    </Button>
-                )}
-            </div>
-        </div>
-    );
 }
 
 export default function EventsList<T extends BaseEvent>({
     events,
     emptyMessage,
+    emptyTitle = "Verlauf aktivieren",
+    ctaLabel = "Event eintragen",
     getTitle,
     onAddEvent,
     children,
 }: EventsListProps<T>) {
-    const isEmpty = !events || events.length === 0;
+    const isEmpty = events.length === 0;
 
     const displayEvents = useMemo(
         () => (isEmpty ? (generateExampleEvents() as unknown as T[]) : events),
@@ -128,39 +89,43 @@ export default function EventsList<T extends BaseEvent>({
 
     const groups = groupEventsByDate(displayEvents);
 
-    return (
+    const eventGroups = (
         <div className={styles.container}>
-            <div className={isEmpty ? styles.ghostContent : undefined}>
-                {groups.map(([date, groupedEvents]) => (
-                    <section key={date}>
-                        <header className={styles.dateHeader}>
-                            <h3 className={styles.dateTitle}>
-                                {formatDate(dateKeyToTimestamp(date))}
-                            </h3>
-                            <div className={styles.dateLine} />
-                        </header>
-
-                        <ol className={styles.eventsGrid}>
-                            {groupedEvents.map((event) => (
-                                <li key={event.id} className={styles.timelineItem}>
-                                    {children ? (
-                                        children(event)
-                                    ) : (
-                                        <EventCard
-                                            event={event}
-                                            title={getTitle(event)}
-                                        />
-                                    )}
-                                </li>
-                            ))}
-                        </ol>
-                    </section>
-                ))}
-            </div>
-
-            {isEmpty && (
-                <ExampleOverlay message={emptyMessage} onAddEvent={onAddEvent} />
-            )}
+            {groups.map(([date, groupedEvents]) => (
+                <section key={date}>
+                    <header className={styles.dateHeader}>
+                        <h3 className={styles.dateTitle}>
+                            {formatDate(dateKeyToTimestamp(date))}
+                        </h3>
+                        <div className={styles.dateLine} />
+                    </header>
+                    <ol className={styles.eventsGrid}>
+                        {groupedEvents.map((event) => (
+                            <li key={event.id} className={styles.timelineItem}>
+                                {children ? children(event) : (
+                                    <EventCard event={event} title={getTitle(event)} />
+                                )}
+                            </li>
+                        ))}
+                    </ol>
+                </section>
+            ))}
         </div>
+    );
+
+    return (
+        <GhostState
+            isEmpty={isEmpty}
+            overlay={
+                <GhostCard
+                    title={emptyTitle}
+                    text={emptyMessage}
+                    cta={ctaLabel}
+                    onClick={onAddEvent}
+                />
+            }
+        >
+            {eventGroups}
+        </GhostState>
     );
 }

--- a/src/app/environments/[environmentId]/components/shared/GhostState/GhostCard.module.scss
+++ b/src/app/environments/[environmentId]/components/shared/GhostState/GhostCard.module.scss
@@ -1,0 +1,29 @@
+.ghostOverlayCard {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--spacing-m);
+  text-align: center;
+  background-color: var(--color-background-primary);
+  border: 1px solid var(--color-border-primary);
+  border-radius: var(--radius-l);
+  padding: var(--spacing-xl);
+  max-width: 320px;
+  width: 100%;
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.12);
+}
+
+.ghostOverlayTitle {
+  font-size: var(--font-size-m);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  margin: 0;
+}
+
+.ghostOverlayText {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-tertiary);
+  max-width: 240px;
+  line-height: 1.5;
+  margin: 0;
+}

--- a/src/app/environments/[environmentId]/components/shared/GhostState/GhostCard.tsx
+++ b/src/app/environments/[environmentId]/components/shared/GhostState/GhostCard.tsx
@@ -1,0 +1,25 @@
+import { Sprout } from 'lucide-react';
+import { Button } from '@/components/Button/Button';
+import styles from './GhostCard.module.scss';
+
+interface GhostCardProps {
+    title: string;
+    text: string;
+    cta?: string;
+    onClick?: () => void;
+}
+
+export function GhostCard({ title, text, cta, onClick }: GhostCardProps) {
+    return (
+        <div className={styles.ghostOverlayCard}>
+            <Sprout size={28} strokeWidth={1.5} aria-hidden />
+            <h3 className={styles.ghostOverlayTitle}>{title}</h3>
+            <p className={styles.ghostOverlayText}>{text}</p>
+            {cta && onClick && (
+                <Button variant="secondary" onClick={onClick}>
+                    {cta}
+                </Button>
+            )}
+        </div>
+    );
+}

--- a/src/app/environments/[environmentId]/components/shared/GhostState/GhostState.module.scss
+++ b/src/app/environments/[environmentId]/components/shared/GhostState/GhostState.module.scss
@@ -1,0 +1,19 @@
+.ghostWrapper {
+  position: relative;
+}
+
+.ghostContent {
+  opacity: 0.5;
+  filter: saturate(0.4);
+  pointer-events: none;
+  user-select: none;
+}
+
+.ghostOverlay {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xl);
+}

--- a/src/app/environments/[environmentId]/components/shared/GhostState/GhostState.tsx
+++ b/src/app/environments/[environmentId]/components/shared/GhostState/GhostState.tsx
@@ -1,0 +1,22 @@
+import styles from './GhostState.module.scss';
+
+interface GhostStateProps {
+    isEmpty: boolean;
+    children: React.ReactNode;
+    overlay: React.ReactNode;
+}
+
+export function GhostState({ isEmpty, children, overlay }: GhostStateProps) {
+    if (!isEmpty) return children;
+
+    return (
+        <div className={styles.ghostWrapper}>
+            <div className={styles.ghostContent} aria-hidden>
+                {children}
+            </div>
+            <div className={styles.ghostOverlay}>
+                {overlay}
+            </div>
+        </div>
+    );
+}

--- a/src/config/environmentTableConfig.tsx
+++ b/src/config/environmentTableConfig.tsx
@@ -1,5 +1,4 @@
 import { EnvironmentTableRow } from "@/components/Table/adapters/environmentTableAdapter";
-import { formatDateShort } from "@/helpers/date";
 import type { TableConfig } from "@/types/table";
 import { CLIMATE_COLORS } from "./icons";
 import { ENVIRONMENT_LABELS } from "./environment";

--- a/src/helpers/createGhostEnvironmnetRow.ts
+++ b/src/helpers/createGhostEnvironmnetRow.ts
@@ -1,0 +1,46 @@
+import { EnvironmentTableRow } from '@/components/Table/adapters/environmentTableAdapter';
+import { getProfile } from '@/config/profiles';
+
+export function createGhostEnvironmentRow(
+  overrides: Partial<EnvironmentTableRow>
+): EnvironmentTableRow {
+  return {
+    key: 'ghost',
+    name: 'Ghost',
+    type: 'indoor',
+    location: null,
+    profiles: [getProfile('generic')],
+
+    lastTemp: null,
+    lastTempUnit: '°C',
+    tempBad: false,
+
+    lastHumidity: null,
+    humidityBad: false,
+
+    lastVpd: null,
+    vpdBad: false,
+
+    lastCo2: null,
+    co2Bad: false,
+
+    lastMeasurementTimestamp: 0,
+    lastMeasurementDate: null,
+    daysSinceLastMeasurement: 0,
+
+    lastEventType: null,
+    lastEventTimestamp: 0,
+    lastEventFormatted: null,
+
+    profilesLabel: '—',
+
+    events: [],
+
+    tempHistory: [],
+    humidityHistory: [],
+    vpdHistory: [],
+    co2History: [],
+
+    ...overrides,
+  };
+}

--- a/src/helpers/createGhostPlantRow.ts
+++ b/src/helpers/createGhostPlantRow.ts
@@ -1,0 +1,35 @@
+import { PlantTableRow } from '@/components/Table/adapters/plantTableAdapter';
+
+export function createGhostPlantRow(
+    overrides: Partial<PlantTableRow>
+): PlantTableRow {
+    return {
+        key: 'ghost',
+        title: 'Ghost',
+        species: '',
+        environmentId: '',
+
+        phValue: null,
+        phUnit: null,
+        phBad: false,
+
+        ecValue: null,
+        ecUnit: null,
+        ecBad: false,
+
+        lastEventType: null,
+        lastEventTimestamp: 0,
+        lastEventFormatted: null,
+
+        lastWateringTimestamp: 0,
+        lastWateringDate: null,
+        daysSinceWatering: 999,
+
+        events: [],
+
+        phHistory: [],
+        ecHistory: [],
+
+        ...overrides,
+    };
+}

--- a/src/hooks/useDeleteEnvironments.ts
+++ b/src/hooks/useDeleteEnvironments.ts
@@ -1,0 +1,17 @@
+import { useCallback } from "react";
+import { useEnvironment } from "@/context/EnvironmentContext";
+import { usePlant } from "@/context/PlantContext";
+
+export function useDeleteEnvironments() {
+    const { deleteEnvironments } = useEnvironment();
+    const { plants, deletePlants } = usePlant();
+
+    return useCallback((ids: string[]) => {
+        const orphanedPlantIds = plants
+            .filter(p => ids.includes(p.environmentId))
+            .map(p => p.id!);
+
+        if (orphanedPlantIds.length > 0) deletePlants(orphanedPlantIds);
+        deleteEnvironments(ids);
+    }, [deleteEnvironments, deletePlants, plants]);
+}


### PR DESCRIPTION
Replace scattered empty state implementations with a shared GhostState/GhostCard component pair. All tabs now show blurred placeholder content with a centered overlay card instead of blank states or plain text messages.

Affected areas:
- EnvironmentTab (desktop + mobile)
- PlantsTab
- EventsList
- DataTab (Klimadaten + Wasserwerte)
- RecentActivityTab

Also adds useDeleteEnvironments hook to cascade plant deletion when an environment is removed.